### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ malwaRE
 Malware repository framework
  
 
-####Description
+#### Description
  
 `malwaRE` is a malware repository website created using PHP Laravel framework, used to manage your own malware zoo. `malwaRE` was based on the work of 
 [Adlice](http://www.adlice.com/softwares/malware-repository-framework/) team with some extra features.
 
 If you guys have any improvements, please let me know or send me a pull request.
 
-####Features
+#### Features
  - Self-hosted solution (PHP/Mysql server needed)
  - VirusTotal results (option for uploading unknown samples)
  - Search filters available (vendor, filename, hash, tag)
@@ -21,7 +21,7 @@ If you guys have any improvements, please let me know or send me a pull request.
  - VirusTotal rescan button (VirusTotal's score column)
  - Download samples from repository
  
-####Installation
+#### Installation
 - Download project by running command `git clone git@github.com:c633/malwaRE.git`
 - Change line `29` of `bootstrap/start.php` to your computer hostname (on Linux or Max, you can determine your hostname using `hostname` terminal command)
 - Edit `your-computer-name-here` and `your-name-here` in `app/views/index.blade.php` to whatever you want.
@@ -45,7 +45,7 @@ return array(
 - You are done.
 
 
-####Screenshots
+#### Screenshots
 ![Repository](https://raw.githubusercontent.com/c633/malwaRE/master/screenshots/sample.png)
 
 ![Writeups modal](https://raw.githubusercontent.com/c633/malwaRE/master/screenshots/writeups.png)

--- a/vendor/filp/whoops/LICENSE.md
+++ b/vendor/filp/whoops/LICENSE.md
@@ -1,4 +1,4 @@
-#The MIT License
+# The MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
